### PR TITLE
Support macOS & Windows

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,3 +1,4 @@
+---
 name: "Tagger - Move semantic tags!"
 description: "Automatically move your semantic tags on release."
 branding:
@@ -19,23 +20,25 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: robinraju/release-downloader@v1.3
-      with:
-        repository: "fischerscode/tagger"
-        fileName: "tagger.linux"
-        out-file-path: ${{ github.action_path }}
-        tag: v0.1.0
-    - run: |
-        mv ${{ github.action_path }}/tagger.linux ${{ github.action_path }}/tagger
+    - name: Download tagger
+      run: |
+        if [ "${{ runner.os }}" = "Linux" ]; then
+          suffix=linux
+        elif [ "${{ runner.os }}" = "macOS" ]; then
+          suffix=mac
+        else
+          suffix=windows.exe
+        fi
+        wget https://github.com/fischerscode/tagger/releases/download/v0.1.0/tagger.${suffix} -O ${{ github.action_path }}/tagger
         chmod +x ${{ github.action_path }}/tagger
-      shell: bash
-    - run: ${{ github.action_path }}/tagger move -s -p '${{inputs.prefix}}' ${INPUTS_TAG##*/}
+      shell: sh
+    - run: ${{ github.action_path }}/tagger move -s -p '${{ inputs.prefix }}' ${INPUTS_TAG##*/}
       shell: bash
       env:
-        INPUTS_TAG: ${{inputs.tag}}
+        INPUTS_TAG: ${{ inputs.tag }}
     - run: rm ${{ github.action_path }}/tagger
-      shell: bash
+      shell: sh
     - run: |
-        repo="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        repo=$(echo "${{ github.repositoryUrl }}" | sed "s,git://,https://${GITHUB_ACTOR}:${INPUT_TOKEN}@,")
         git push "$repo" --tags --force
-      shell: bash
+      shell: sh

--- a/action.yaml
+++ b/action.yaml
@@ -24,12 +24,14 @@ runs:
       id: info
       run: |
         if [ "${{ runner.os }}" = "Windows" ]; then
-          bin=${{ runner.temp }}\\tagger.exe
+          bin=$DIR\\tagger.exe
         else
-          bin="${{ runner.temp }}/tagger"
+          bin="$DIR/tagger"
         fi
         echo "BIN=$bin" >> $GITHUB_OUTPUT
       shell: sh
+      env:
+        DIR: ${{ runner.temp }}
     - name: Download tagger (Linux, macOS)
       if: ${{ runner.os != 'Windows' }}
       run: |
@@ -43,14 +45,21 @@ runs:
       shell: sh
     - name: Download tagger (Windows)
       if: ${{ runner.os == 'Windows' }}
-      run: Invoke-WebRequest -URI https://github.com/fischerscode/tagger/releases/download/v0.1.0/tagger.windows.exe -OutFile ${{ steps.info.outputs.BIN }}
+      run: |
+        Invoke-WebRequest -URI https://github.com/fischerscode/tagger/releases/download/v0.1.0/tagger.windows.exe -OutFile $Env:BIN
+        echo "Saved to $Env:BIN"
       shell: pwsh
-    - run: ${{ steps.info.outputs.BIN }} move -s -p '${{ inputs.prefix }}' ${INPUTS_TAG##*/}
+      env:
+        BIN: ${{ steps.info.outputs.BIN }}
+    - run: $BIN move -s -p '${{ inputs.prefix }}' ${INPUTS_TAG##*/}
       shell: bash
       env:
         INPUTS_TAG: ${{ inputs.tag }}
-    - run: rm ${{ steps.info.outputs.BIN }}
+        BIN: ${{ steps.info.outputs.BIN }}
+    - run: rm $BIN
       shell: sh
+      env:
+        BIN: ${{ steps.info.outputs.BIN }}
     - run: |
         repo=$(echo "${{ github.repositoryUrl }}" | sed "s,git://,https://${GITHUB_ACTOR}:${INPUT_TOKEN}@,")
         git push "$repo" --tags --force

--- a/action.yaml
+++ b/action.yaml
@@ -20,23 +20,36 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Download tagger
+    - name: Collect info
+      id: info
+      run: |
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          bin=${{ runner.temp }}\tagger.exe
+        else
+          bin="${{ runner.temp }}/tagger"
+        fi
+        echo "BIN=$bin" >> $GITHUB_OUTPUT
+      shell: sh
+    - name: Download tagger (Linux, macOS)
+      if: ${{ runner.os != 'Windows' }}
       run: |
         if [ "${{ runner.os }}" = "Linux" ]; then
           suffix=linux
-        elif [ "${{ runner.os }}" = "macOS" ]; then
-          suffix=mac
         else
-          suffix=windows.exe
+          suffix=mac
         fi
-        wget https://github.com/fischerscode/tagger/releases/download/v0.1.0/tagger.${suffix} -O ${{ github.action_path }}/tagger
-        chmod +x ${{ github.action_path }}/tagger
+        wget https://github.com/fischerscode/tagger/releases/download/v0.1.0/tagger.${suffix} -O ${{ steps.info.outputs.BIN }}
+        chmod +x ${{ steps.info.outputs.BIN }}
       shell: sh
-    - run: ${{ github.action_path }}/tagger move -s -p '${{ inputs.prefix }}' ${INPUTS_TAG##*/}
+    - name: Download tagger (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      run: Invoke-WebRequest -URI https://github.com/fischerscode/tagger/releases/download/v0.1.0/tagger.windows.exe -OutFile ${{ steps.info.outputs.BIN }}
+      shell: pwsh
+    - run: ${{ steps.info.outputs.BIN }} move -s -p '${{ inputs.prefix }}' ${INPUTS_TAG##*/}
       shell: bash
       env:
         INPUTS_TAG: ${{ inputs.tag }}
-    - run: rm ${{ github.action_path }}/tagger
+    - run: rm ${{ steps.info.outputs.BIN }}
       shell: sh
     - run: |
         repo=$(echo "${{ github.repositoryUrl }}" | sed "s,git://,https://${GITHUB_ACTOR}:${INPUT_TOKEN}@,")

--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ runs:
       id: info
       run: |
         if [ "${{ runner.os }}" = "Windows" ]; then
-          bin=${{ runner.temp }}\tagger.exe
+          bin=${{ runner.temp }}\\tagger.exe
         else
           bin="${{ runner.temp }}/tagger"
         fi


### PR DESCRIPTION
# Changelog

1. Replaced hardcoded `github.com` in the last step with `${{ github.repositoryUrl }}`.
2. Replaced `robinraju/release-downloader` usage with simple `wget`.
3. Support windows and macos runners. Instead of hardcoded `tagger.linux` it should select proper binary based on runner OS.

# Notes

1st and 2nd changes enable uses to use this GitHub action in GitHub Enterprise Server (GHES). Some companies for security reasons after security reviews clone GitHub actions from github.com into om prem GitHub servers. Hardcoded `github.com` value was a blocker for that because GitHub server has different URL, hence it would fail on this step. Also, using `robinraju/release-downloader` action is another blocker as there is no such action on GHES, and even if it also cloned beforehand, it has another organization and another repo name. So, there was 2 ways to fix this part - have the name of this action as an optional `input` and allow users to define the name of the action themselves or simply do not use it and use a simple `wget`. I choose second option since it is not very difficult change.

Please review and let me know your thoughts. Thank you.